### PR TITLE
libpmc: fix linking with C programs

### DIFF
--- a/lib/libpmc/Makefile
+++ b/lib/libpmc/Makefile
@@ -6,6 +6,7 @@ SRCS=	libpmc.c pmclog.c libpmc_pmu_util.c libpmc_json.cc
 INCS=	pmc.h pmclog.h pmcformat.h
 
 CFLAGS+= -I${SRCTOP}/${RELDIR:H}/libpmcstat
+LDADD+=	-lc++
 
 .if ${MACHINE_CPUARCH} == "aarch64" || ${MACHINE_ARCH} == "amd64" || \
     ${MACHINE_ARCH} == "i386"


### PR DESCRIPTION
Revision r334749 Added some C++ code to libpmc.  It didn't change the ABI,
but it did introduce a dependency on libc++.  Nobody noticed because every
program that in the base system that uses libpmc is also C++.

Reported-by:	Dom Dwyer <dom@itsallbroken.com>
Reviewed By:	vangyzen
Differential Revision: https://reviews.freebsd.org/D28550

(cherry picked from commit 04e34c0202ea50cea67d5779f54bc612c74e6532)